### PR TITLE
Container image support and Action building/publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,3 +31,42 @@ jobs:
         run: poetry publish --build
         env:
           POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+
+  image:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Read Poetry TOML
+        uses: SebRollen/toml-action@v1.0.2
+        id: read_toml
+        with:
+          file: 'pyproject.toml'
+          field: 'tool.poetry.version'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ steps.read_toml.outputs.value }}
+            ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM python:3.10.12-bullseye as base
+
+ENV PYTHONFAULTHANDLER=1 \
+    PYTHONHASHSEED=random \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+FROM base as builder
+
+ENV PIP_DEFAULT_TIMEOUT=100 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    POETRY_VERSION=1.5.1
+
+RUN pip install "poetry==$POETRY_VERSION"
+RUN python -m venv /venv
+
+COPY pyproject.toml poetry.lock README.md ./
+COPY cgroups_exporter ./cgroups_exporter
+
+RUN poetry config virtualenvs.in-project true && \
+    poetry install --only=main --no-root --no-dev && \
+    poetry build
+
+FROM python:3.10.12-slim-bullseye as final
+
+COPY --from=builder /app/dist/*.whl .
+
+RUN pip install *.whl
+RUN rm *.whl
+
+CMD ["/usr/local/bin/cgroups-exporter"]
+
+EXPOSE 9753

--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ Default values will based on following configuration files ['cgroups-exporter.co
 sections.See more https://pypi.org/project/argclass/#configs
 ```
 
+Container Usage
+---------------
+
+`cgroups-exporter` is also available as a container image to be used in Docker, Kubernetes or other runtimes. It expects the host `/sys` directory to be mounted in the container (read only).
+
+Docker usage example:
+
+```shell
+docker run -p 9753:9753 -v /sys/:/host_sys/ ghcr.io/mosquito/cgroups-exporter:latest cgroups-exporter --cgroups-path "/host_sys/fs/cgroup/*/docker/*"
+```
+
+
 Metrics
 -------
 


### PR DESCRIPTION
👋 @mosquito! First time contributor here.

I happen to work at a project where I need the exporter to run in a Kubernetes environment, so naturally I packaged it as a container.

I wondered if that could be useful in general to have in your repo.

This PR adds a Dockerfile and a new job in the `publish` GitHub Action, the only requirement being to allow Actions to write into packages:

![image](https://github.com/mosquito/cgroups-exporter/assets/250541/df5bfa1d-0f89-4430-8682-5b56064a40f0)

(this is the simplest way, as the comment says, you might want to actually use granular permissions)

Let me know whether this is something you are open to accept.

Have a nice day!